### PR TITLE
Draft sub-command idea

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arg"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["Douman <douman@gmx.se>"]
 edition = "2018"
 repository = "https://github.com/DoumanAsh/arg.rs"
@@ -22,7 +22,7 @@ keywords = [
 categories = ["command-line-interface"]
 
 [dependencies.arg-derive]
-version = "0.3"
+version = "0.4"
 path = "arg-derive/"
 
 [features]

--- a/arg-derive/Cargo.toml
+++ b/arg-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arg-derive"
-version = "0.3.5"
+version = "0.4.0"
 authors = ["Douman <douman@gmx.se>"]
 edition = "2018"
 repository = "https://github.com/DoumanAsh/arg.rs"

--- a/arg-derive/src/lib.rs
+++ b/arg-derive/src/lib.rs
@@ -2,7 +2,11 @@
 
 extern crate proc_macro;
 
+mod utils;
+use utils::*;
+
 use proc_macro::TokenStream;
+use quote::quote;
 
 use core::fmt::Write;
 
@@ -30,6 +34,12 @@ struct Opt {
     typ: OptValueType,
 }
 
+struct Command {
+    variant_name: String,
+    command_name: String,
+    desc: String,
+}
+
 const FROM_FN: &str = "core::str::FromStr::from_str";
 const TAB: &str = "    ";
 const PARSER_TRAIT: &str = "arg::Args";
@@ -48,6 +58,158 @@ fn parse_segment(segment: &syn::PathSegment) -> OptValueType {
     } else {
         OptValueType::Value
     }
+}
+
+fn from_enum(ast: &syn::DeriveInput, payload: &syn::DataEnum) -> TokenStream {
+    let mut about_prog = String::new();
+    for attr in ast.attrs.iter().filter_map(|attr| attr.parse_meta().ok()) {
+        match attr {
+            syn::Meta::NameValue(value) => if value.path.is_ident("doc") {
+                if let syn::Lit::Str(ref text) = value.lit {
+                    about_prog.push_str(&text.value());
+                    about_prog.push_str("\n");
+                }
+            } else {
+            },
+            _ => (),
+        }
+    }
+    about_prog.pop();
+
+    let mut commands = Vec::new();
+    for variant in payload.variants.iter() {
+        let mut desc = String::new();
+        let variant_name = variant.ident.to_string();
+        if variant_name.is_empty() {
+            return syn::Error::new_spanned(&variant.ident, "Oi, mate, You cannot have enum variant without name").to_compile_error().into()
+        }
+        let command_name = to_hyphenated_lower_case(&variant_name);
+        if command_name.eq_ignore_ascii_case("help") {
+            return syn::Error::new_spanned(&variant.ident, "Oi, mate, You cannot use variant 'Help'").to_compile_error().into()
+        }
+
+        for attr in variant.attrs.iter().filter_map(|attr| attr.parse_meta().ok()) {
+            match attr {
+                syn::Meta::NameValue(value) => if value.path.is_ident("doc") {
+                    if let syn::Lit::Str(ref text) = value.lit {
+                        desc.push_str(&text.value());
+                        desc.push_str(" ");
+                    }
+                },
+                _ => continue
+            }
+        }
+
+        let field = match &variant.fields {
+            syn::Fields::Unit => return syn::Error::new_spanned(&variant.fields, "Unit variant cannot be used").to_compile_error().into(),
+            syn::Fields::Named(_) => return syn::Error::new_spanned(&variant.fields, "I'm too lazy to support named variant").to_compile_error().into(),
+            syn::Fields::Unnamed(fields) => {
+                if fields.unnamed.empty_or_trailing() {
+                    return syn::Error::new_spanned(&fields, "MUST specify single field").to_compile_error().into();
+                } else if fields.unnamed.len() > 1 {
+                    return syn::Error::new_spanned(&fields, "MUST not specify more than 1 field").to_compile_error().into();
+                } else {
+                    fields.unnamed.first().unwrap()
+                }
+            },
+        };
+
+        match &field.ty {
+            syn::Type::Path(ref ty) => {
+                let ty = ty.path.segments.last().expect("To have at least one segment");
+                if ty.ident == "Option" {
+                    return syn::Error::new_spanned(&ty, "Command cannot be optional").to_compile_error().into()
+                } else {
+                    match parse_segment(ty) {
+                        OptValueType::Bool => return syn::Error::new_spanned(&ty, "Command value cannot be boolean").to_compile_error().into(),
+                        OptValueType::MultiValue => return syn::Error::new_spanned(&ty, "Command value Vec<_>").to_compile_error().into(),
+                        _ => (),
+                    }
+                }
+            },
+            ty => {
+                return syn::Error::new_spanned(&ty, "Expected simple ident or path").to_compile_error().into()
+            }
+        }
+
+        commands.push(Command {
+            command_name,
+            variant_name,
+            desc
+        })
+    }
+
+    if commands.is_empty() {
+        return syn::Error::new_spanned(&ast, "Enum must have at least one variant").to_compile_error().into()
+    }
+
+    let (impl_gen, type_gen, where_clause) = ast.generics.split_for_impl();
+
+    let help_msg = {
+        use std::io::Write;
+        use tabwriter::TabWriter;
+
+        let mut tw = TabWriter::new(vec![]);
+
+        let _ = write!(tw, "COMMANDS:\n");
+        for command in commands.iter() {
+            let _ = write!(tw, "\t{}\t{}\n", command.command_name, command.desc);
+        }
+
+        let _ = tw.flush();
+
+        String::from_utf8(tw.into_inner().unwrap()).unwrap()
+    };
+
+    let mut result = String::new();
+    let _ = writeln!(result, "{} {} for {}{} {{", quote!(impl#impl_gen), PARSER_TRAIT, ast.ident, quote!(#type_gen #where_clause));
+
+    let _ = writeln!(result, "{}const HELP: &'static str = \"{}\";", TAB, help_msg);
+
+    //from_args START
+    let _ = writeln!(result, "{}fn from_args<'a, T: IntoIterator<Item = &'a str>>(_args_: T) -> Result<Self, arg::ParseKind<'a>> {{", TAB);
+
+    let _ = writeln!(result, "{0}{0}let mut _args_ = _args_.into_iter();\n", TAB);
+
+    //args START
+    let _ = writeln!(result, "{0}{0}while let Some(_arg_) = _args_.next() {{", TAB);
+
+    //help
+    let _ = writeln!(result, "{0}{0}{0}if _arg_.eq_ignore_ascii_case(\"help\") {{", TAB);
+    let _ = writeln!(result, "{0}{0}{0}{0}return Err(arg::ParseKind::Top(arg::ParseError::HelpRequested(Self::HELP)));", TAB);
+    let _ = write!(result, "{0}{0}{0}}}", TAB);
+
+    for command in commands.iter() {
+        //arg START
+        let _ = writeln!(result, " else if _arg_.eq_ignore_ascii_case(\"{}\") {{", command.command_name);
+
+        let _ = writeln!(result, "{0}{0}{0}{0}match {1}::from_args(_args_) {{", TAB, PARSER_TRAIT);
+        let _ = writeln!(result, "{0}{0}{0}{0}{0}Ok(res) => return Ok(Self::{1}(res)),", TAB, command.variant_name);
+        let _ = writeln!(result, "{0}{0}{0}{0}{0}Err(arg::ParseKind::Top(error)) => return Err(arg::ParseKind::Sub(\"{1}\", error)),", TAB, command.command_name);
+        let _ = writeln!(result, "{0}{0}{0}{0}{0}Err(arg::ParseKind::Sub(name, error)) => return Err(arg::ParseKind::Sub(name, error)),", TAB);
+        let _ = writeln!(result, "{0}{0}{0}{0}}}", TAB);
+
+        //arg END
+        let _ = write!(result, "{0}{0}{0}}}", TAB);
+    }
+
+    //args END
+    let _ = writeln!(result, "\n{0}{0}}}", TAB);
+
+    let _ = writeln!(result, "{0}{0}Err(arg::ParseKind::Top(arg::ParseError::RequiredArgMissing(\"command\")))", TAB);
+
+    //from_args END
+    let _ = writeln!(result, "{}}}", TAB);
+
+    let _ = writeln!(result, "}}");
+
+    if let Ok(val) = std::env::var("ARG_RS_PRINT_PARSER") {
+        match val.trim() {
+            "0" | "false" => (),
+            _ => println!("{result}"),
+        }
+    }
+    result.parse().expect("To parse generated code")
 }
 
 fn from_struct(ast: &syn::DeriveInput, payload: &syn::DataStruct) -> TokenStream {
@@ -84,6 +246,7 @@ fn from_struct(ast: &syn::DeriveInput, payload: &syn::DataStruct) -> TokenStream
         typ: OptValueType::Help,
     });
 
+    let mut sub_command = None;
     let mut multi_argument = None;
 
     for field in payload.fields.iter() {
@@ -93,6 +256,7 @@ fn from_struct(ast: &syn::DeriveInput, payload: &syn::DataStruct) -> TokenStream
         let mut short = None;
         let mut long = None;
         let mut required = false;
+        let mut is_sub = false;
 
         let (is_optional, typ) = match field.ty {
             syn::Type::Path(ref ty) => {
@@ -151,7 +315,13 @@ fn from_struct(ast: &syn::DeriveInput, payload: &syn::DataStruct) -> TokenStream
                                         } else {
                                             return syn::Error::new_spanned(value_attr, INVALID_REQUIRED_BOOL).to_compile_error().into();
                                         }
-                                    },
+                                    } else if value_attr.is_ident("sub") {
+                                        if typ == OptValueType::Value {
+                                            is_sub = true;
+                                        } else {
+                                            return syn::Error::new_spanned(value_attr, "Sub-command must be simple value").to_compile_error().into();
+                                        }
+                                    }
                                     syn::Meta::NameValue(value_attr) => if value_attr.path.is_ident("short") {
                                         if let syn::Lit::Str(ref text) = value_attr.lit {
                                             let value_attr_text = text.value();
@@ -203,6 +373,10 @@ fn from_struct(ast: &syn::DeriveInput, payload: &syn::DataStruct) -> TokenStream
             return syn::Error::new_spanned(field.ident.clone(), "Marked as required, but default value is provided?").to_compile_error().into();
         } else if is_optional && default.is_some() {
             return syn::Error::new_spanned(field.ident.clone(), "Optional, but default value is provided?").to_compile_error().into();
+        } else if is_sub && is_optional {
+            return syn::Error::new_spanned(field.ident.clone(), "Sub-command cannot be optional").to_compile_error().into();
+        } else if is_sub && default.is_some() {
+            return syn::Error::new_spanned(field.ident.clone(), "Sub-command cannot have default value").to_compile_error().into();
         } else if !required && !is_optional && default.is_none() {
             default = Some(DEFAULT_INIT.to_owned());
         }
@@ -211,6 +385,8 @@ fn from_struct(ast: &syn::DeriveInput, payload: &syn::DataStruct) -> TokenStream
             if typ == OptValueType::MultiValue {
                 if multi_argument.is_some() {
                     return syn::Error::new_spanned(field.ident.clone(), "Second argument collection. There can be only one").to_compile_error().into();
+                } else if sub_command.is_some() {
+                    return syn::Error::new_spanned(field.ident.clone(), "Multi-argument collection and sub-command are mutually exclusive").to_compile_error().into();
                 }
 
                 multi_argument = Some(Argument {
@@ -222,6 +398,21 @@ fn from_struct(ast: &syn::DeriveInput, payload: &syn::DataStruct) -> TokenStream
                     default,
                 });
 
+            } else if is_sub {
+                if sub_command.is_some() {
+                    return syn::Error::new_spanned(field.ident.clone(), "Second sub-command. There can be only one").to_compile_error().into();
+                } else if multi_argument.is_some() {
+                    return syn::Error::new_spanned(field.ident.clone(), "Sub-command and multi-argument collection are mutually exclusive").to_compile_error().into();
+                }
+
+                sub_command = Some(Argument {
+                    field_name,
+                    name,
+                    desc,
+                    required: true,
+                    is_optional: false,
+                    default: None,
+                });
             } else {
                 arguments.push(Argument {
                     field_name,
@@ -285,6 +476,8 @@ USAGE:", about_prog);
             } else {
                 write!(tw, " [{}]...", argument.name)
             };
+        } else if let Some(argument) = sub_command.as_ref() {
+            let _ = write!(tw, " <{}>", argument.name);
         }
 
         if !options.is_empty() {
@@ -309,7 +502,7 @@ USAGE:", about_prog);
             let _ = write!(tw, "\t{}\n", option.arg.desc);
         }
 
-        if !arguments.is_empty() || multi_argument.is_some() {
+        if !arguments.is_empty() || multi_argument.is_some() || sub_command.is_some() {
             let _ = write!(tw, "\nARGS:\n");
         }
 
@@ -323,6 +516,8 @@ USAGE:", about_prog);
 
         if let Some(argument) = multi_argument.as_ref() {
             let _ = writeln!(tw, "\t<{}>...\t{}", argument.name, argument.desc);
+        } else if let Some(command) = sub_command.as_ref() {
+            let _ = writeln!(tw, "\t<{}>\t{}", command.name, command.desc);
         }
 
         let _ = tw.flush();
@@ -330,13 +525,11 @@ USAGE:", about_prog);
         String::from_utf8(tw.into_inner().unwrap()).unwrap()
     };
 
-    use quote::quote;
-
     let mut result = String::new();
     let _ = writeln!(result, "{} {} for {}{} {{", quote!(impl#impl_gen), PARSER_TRAIT, ast.ident, quote!(#type_gen #where_clause));
     let _ = writeln!(result, "{}const HELP: &'static str = \"{}\";", TAB, help_msg);
 
-    let _ = writeln!(result, "{}fn from_args<'a, T: IntoIterator<Item = &'a str>>(_args_: T) -> Result<Self, arg::ParseError<'a>> {{", TAB);
+    let _ = writeln!(result, "{}fn from_args<'a, T: IntoIterator<Item = &'a str>>(_args_: T) -> Result<Self, arg::ParseKind<'a>> {{", TAB);
 
     for option in options.iter() {
         if option.arg.field_name == "_" {
@@ -356,6 +549,8 @@ USAGE:", about_prog);
 
     if let Some(argument) = multi_argument.as_ref() {
         let _ = writeln!(result, "{0}{0}let mut {1} = Vec::new();", TAB, argument.field_name);
+    } else if let Some(command) = sub_command.as_ref() {
+        let _ = writeln!(result, "{0}{0}let mut {1} = None;", TAB, command.field_name);
     }
 
     let _ = writeln!(result, "{0}{0}let mut _args_ = _args_.into_iter();\n", TAB);
@@ -364,7 +559,7 @@ USAGE:", about_prog);
     //options
     let _ = writeln!(result, "{0}{0}{0}if let Some(_arg_) = _arg_.strip_prefix('-') {{", TAB);
     let _ = writeln!(result, "{0}{0}{0}{0}match _arg_ {{", TAB);
-    let _ = writeln!(result, "{0}{0}{0}{0}{0}\"h\" | \"-help\" => return Err(arg::ParseError::HelpRequested(Self::HELP)),", TAB);
+    let _ = writeln!(result, "{0}{0}{0}{0}{0}\"h\" | \"-help\" => return Err(arg::ParseKind::Top(arg::ParseError::HelpRequested(Self::HELP))),", TAB);
     let _ = writeln!(result, "{0}{0}{0}{0}{0}\"\" => (),", TAB);
 
     for option in options.iter() {
@@ -386,21 +581,21 @@ USAGE:", about_prog);
             OptValueType::Value => write!(result, "match _args_.next() {{
 {0}{0}{0}{0}{0}{0}Some(_next_arg_) => match {1}(_next_arg_) {{
 {0}{0}{0}{0}{0}{0}{0}Ok(value) => {{ {2} = Some(value); continue }},
-{0}{0}{0}{0}{0}{0}{0}Err(_) => return Err(arg::ParseError::InvalidFlagValue(\"{3}\", _next_arg_)),
+{0}{0}{0}{0}{0}{0}{0}Err(_) => return Err(arg::ParseKind::Top(arg::ParseError::InvalidFlagValue(\"{3}\", _next_arg_))),
 {0}{0}{0}{0}{0}{0}}},
-{0}{0}{0}{0}{0}{0}None => return Err(arg::ParseError::MissingValue(\"{3}\")),
+{0}{0}{0}{0}{0}{0}None => return Err(arg::ParseKind::Top(arg::ParseError::MissingValue(\"{3}\"))),
 {0}{0}{0}{0}{0}}}", TAB, FROM_FN, option.arg.field_name, option.arg.name),
             OptValueType::MultiValue => write!(result, "match _args_.next() {{
 {0}{0}{0}{0}{0}{0}Some(_next_arg_) => match {1}(_next_arg_) {{
 {0}{0}{0}{0}{0}{0}{0}Ok(value) => {{ {2}.push(value); continue }},
-{0}{0}{0}{0}{0}{0}{0}Err(_) => return Err(arg::ParseError::InvalidFlagValue(\"{3}\", _next_arg_)),
+{0}{0}{0}{0}{0}{0}{0}Err(_) => return Err(arg::ParseKind::Top(arg::ParseError::InvalidFlagValue(\"{3}\", _next_arg_))),
 {0}{0}{0}{0}{0}{0}}},
-{0}{0}{0}{0}{0}{0}None => return Err(arg::ParseError::MissingValue(\"{3}\")),
+{0}{0}{0}{0}{0}{0}None => return Err(arg::ParseKind::Top(arg::ParseError::MissingValue(\"{3}\"))),
 {0}{0}{0}{0}{0}}}", TAB, FROM_FN, option.arg.field_name, option.arg.name),
         };
         let _ = writeln!(result, "");
     }
-    let _ = writeln!(result, "{0}{0}{0}{0}{0}_ => return Err(arg::ParseError::UnknownFlag(_arg_)),", TAB);
+    let _ = writeln!(result, "{0}{0}{0}{0}{0}_ => return Err(arg::ParseKind::Top(arg::ParseError::UnknownFlag(_arg_))),", TAB);
 
     let _ = writeln!(result, "{0}{0}{0}{0}}}", TAB);
     let _ = writeln!(result, "{0}{0}{0}}}", TAB);
@@ -413,7 +608,7 @@ USAGE:", about_prog);
         }
         let _ = writeln!(result, "{0}{0}{0}{0}match {1}(_arg_) {{", TAB, FROM_FN);
         let _ = writeln!(result, "{0}{0}{0}{0}{0}Ok(_res_) => {1} = Some(_res_),", TAB, arg.field_name);
-        let _ = writeln!(result, "{0}{0}{0}{0}{0}Err(_) => return Err(arg::ParseError::InvalidArgValue(\"{1}\", _arg_)),", TAB, arg.field_name);
+        let _ = writeln!(result, "{0}{0}{0}{0}{0}Err(_) => return Err(arg::ParseKind::Top(arg::ParseError::InvalidArgValue(\"{1}\", _arg_))),", TAB, arg.field_name);
         let _ = writeln!(result, "{0}{0}{0}{0}}}", TAB);
     }
     //too many args?
@@ -424,10 +619,16 @@ USAGE:", about_prog);
     if let Some(arg) = multi_argument.as_ref() {
         let _ = writeln!(result, "{0}{0}{0}{0}match {1}(_arg_) {{", TAB, FROM_FN);
         let _ = writeln!(result, "{0}{0}{0}{0}{0}Ok(_res_) => {1}.push(_res_),", TAB, arg.field_name);
-        let _ = writeln!(result, "{0}{0}{0}{0}{0}Err(_) => return Err(arg::ParseError::InvalidArgValue(\"{1}\", _arg_)),", TAB, arg.field_name);
+        let _ = writeln!(result, "{0}{0}{0}{0}{0}Err(_) => return Err(arg::ParseKind::Top(arg::ParseError::InvalidArgValue(\"{1}\", _arg_))),", TAB, arg.field_name);
+        let _ = writeln!(result, "{0}{0}{0}{0}}}", TAB);
+    } else if let Some(command) = sub_command.as_ref() {
+        let _ = writeln!(result, "{0}{0}{0}{0}match {1}::from_args(core::iter::once(_arg_).chain(_args_)) {{", TAB, PARSER_TRAIT);
+        let _ = writeln!(result, "{0}{0}{0}{0}{0}Ok(_res_) => {{ {1} = Some(_res_); break; }},", TAB, command.field_name);
+        let _ = writeln!(result, "{0}{0}{0}{0}{0}Err(arg::ParseKind::Top(_)) => return Err(arg::ParseKind::Top(arg::ParseError::RequiredArgMissing(\"{1}\"))),", TAB, command.field_name);
+        let _ = writeln!(result, "{0}{0}{0}{0}{0}Err(arg::ParseKind::Sub(name, error)) => return Err(arg::ParseKind::Sub(name, error)),", TAB);
         let _ = writeln!(result, "{0}{0}{0}{0}}}", TAB);
     } else {
-        let _ = writeln!(result, "{0}{0}{0}{0} return Err(arg::ParseError::TooManyArgs);", TAB);
+        let _ = writeln!(result, "{0}{0}{0}{0} return Err(arg::ParseKind::Top(arg::ParseError::TooManyArgs));", TAB);
     }
     //exit args
     if !arguments.is_empty() {
@@ -450,7 +651,7 @@ USAGE:", about_prog);
                 Some(ref default) => writeln!(result, "{0}{0}let {1} = if let Some(value) = {1} {{ value }} else {{ {2} }};", TAB, option.arg.field_name, default),
                 None => match option.arg.is_optional {
                     true => Ok(()),
-                    false => writeln!(result, "{0}{0}let {1} = if let Some(value) = {1} {{ value }} else {{ return Err(arg::ParseError::RequiredArgMissing(\"{2}\")) }};", TAB, option.arg.field_name, option.arg.name),
+                    false => writeln!(result, "{0}{0}let {1} = if let Some(value) = {1} {{ value }} else {{ return Err(arg::ParseKind::Top(arg::ParseError::RequiredArgMissing(\"{2}\"))) }};", TAB, option.arg.field_name, option.arg.name),
                 },
             },
         };
@@ -461,9 +662,13 @@ USAGE:", about_prog);
             Some(ref default) => writeln!(result, "{0}{0}let {1} = if let Some(value) = {1} {{ value }} else {{ {2} }};", TAB, arg.field_name, default),
             None => match arg.is_optional {
                 true => Ok(()),
-                false => writeln!(result, "{0}{0}let {1} = if let Some(value) = {1} {{ value }} else {{ return Err(arg::ParseError::RequiredArgMissing(\"{2}\")) }};", TAB, arg.field_name, arg.name),
+                false => writeln!(result, "{0}{0}let {1} = if let Some(value) = {1} {{ value }} else {{ return Err(arg::ParseKind::Top(arg::ParseError::RequiredArgMissing(\"{2}\"))) }};", TAB, arg.field_name, arg.name),
             }
         };
+    }
+
+    if let Some(command) = sub_command.as_ref() {
+        let _ = writeln!(result, "{0}{0}let {1} = if let Some(value) = {1} {{ value }} else {{ return Err(arg::ParseKind::Top(arg::ParseError::RequiredArgMissing(\"{2}\"))) }};", TAB, command.field_name, command.name);
     }
 
     //Fill result
@@ -486,6 +691,8 @@ USAGE:", about_prog);
     }
 
     if let Some(arg) = multi_argument.as_ref() {
+        let _ = writeln!(result, "{0}{0}{0}{1},", TAB, arg.field_name);
+    } else if let Some(arg) = sub_command.as_ref() {
         let _ = writeln!(result, "{0}{0}{0}{1},", TAB, arg.field_name);
     }
 
@@ -512,6 +719,7 @@ pub fn parser_derive(input: TokenStream) -> TokenStream {
 
     match ast.data {
         syn::Data::Struct(ref data) => from_struct(&ast, data),
+        syn::Data::Enum(ref data) => from_enum(&ast, data),
         _ => syn::Error::new_spanned(ast.ident, INVALID_INPUT_TYPE).to_compile_error().into(),
     }
 }

--- a/arg-derive/src/utils.rs
+++ b/arg-derive/src/utils.rs
@@ -1,0 +1,36 @@
+pub fn to_hyphenated_lower_case(input: &str) -> String {
+    let mut output = String::with_capacity(input.len());
+
+    let mut chars = input.chars();
+    let mut prev_upper = false;
+    if let Some(ch) = chars.next() {
+        if ch.is_uppercase() {
+            prev_upper = true;
+            for ch in ch.to_lowercase() {
+                output.push(ch);
+            }
+        } else {
+            output.push(ch);
+        }
+    }
+
+    for ch in chars {
+        if ch.is_uppercase() {
+            if !prev_upper {
+                output.push('-');
+            }
+
+            for ch in ch.to_lowercase() {
+                output.push(ch);
+            }
+
+            prev_upper = true;
+        } else {
+            output.push(ch);
+
+            prev_upper = false;
+        }
+    }
+
+    output
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@
 //! - `long` - Specifies that it is flag with long switch. Optionally can be supplied with flag.
 //! - `default_value` - Specifies default value to use. Can be supplied with initialization expression as string. Otherwise uses Default trait.
 //! - `required` - Specifies whether argument is required. By default all arguments are optional. But booleans cannot be marked as `required`
+//! - `sub` - Specifies field to be sub-command. There can be only one sub-command and it is mutually exclusive with `Vec<_>` argument to collect rest of arguments. All other options are not applied to `sub` type of field.
 //!
 //! ### Types
 //!
@@ -22,6 +23,7 @@
 //! - Multi Option - switch with `Vec<T>` type, which allows to accumulate multiple values of switch.
 //! - Argument - Plain argument that takes value.
 //! - Multi argument - Collection of arguments that accumulates into `Vec<T>`, there can be only one.
+//! - Sub-command - Propagates rest of arguments to another parser, there ca be only one.
 //!
 //! ### Conversion
 //!
@@ -36,10 +38,9 @@
 //!
 //! ### Sub-command
 //!
-//! Code generate relies on enum to represent handling of sub-commands.
+//! It relies on enum to represent sub-commands.
 //!
-//! Note that when sub-command is used, it is no longer possible to collect multiple arguments into
-//! array, resulting in compilation error.
+//! Note that when sub-command is used, it is no longer possible to collect multiple arguments into array, resulting in compilation error.
 //!
 //! Sub-command consumes all remaining arguments, so top command flags/options must be passed prior sub-command invocation.
 //!
@@ -90,6 +91,8 @@
 //!
 //! # Usage
 //!
+//! Here is comprehensive example to illustrate all ways to handle flags and options
+//!
 //! ```rust
 //! use arg::Args;
 //!
@@ -121,7 +124,7 @@
 //!     ///To store path 2
 //!     path2: String,
 //!
-//!     ///To store rest of paths
+//!     ///To store rest of paths as multi argument collector
 //!     remain_paths: Vec<String>,
 //! }
 //!
@@ -244,7 +247,6 @@ pub trait Args: Sized {
         Self::from_args(Split::from_str(text))
     }
 }
-
 
 #[cfg(feature = "std")]
 ///Parses CLI arguments from `std::env::args()`


### PR DESCRIPTION
Fix #4

Introduce sub-commands via enumeration.
Consideration points:
- Named enum variants (like in clap) are unsupported, hence user MUST define every sub-command as another instance of `Args`. This is obviously making definition verbose, but on other hand it makes code here much simpler and also makes commands much more easier to parse as pattern matching on named arguments is pain when you have tons of arguments.
- Currently it supports only passing `Args` friendly struct, making stuff simple, but consider if we want to allow `MySub(Vec<String>)` which is good for prototype I guess?
- No default value. User must always specify command or `help` manually.
- No optionality.

## Example
```rust
use arg::Args;

#[derive(Args, Debug)]
///First
struct First {
    #[arg(short, long)]
    ///About this flag
    flag: bool,

    #[arg(short = "v", long = "velocity", default_value = "42")]
    ///This is felocity. Default value is 42.
    speed: u32,
}

#[derive(Args, Debug)]
///Second
struct Second {
    #[arg(short = "v", long = "velocity", default_value = "42")]
    ///This is velocity. Default value is 42.
    speed: u32,
    ///To store rest of paths
    paths: Vec<String>,
}

#[derive(Args, Debug)]
///My subcommand with implicit command 'help` to list commands
enum MySubCommand {
    ///my first command
    First(First),
    ///my second command
    Second(Second),
}

#[derive(Args, Debug)]
struct MyArgs {
    #[arg(short, long)]
    ///About this flag
    verbose: bool,
    #[arg(sub)]
    ///My sub command. Use `help` to show list of commands.
    cmd: MySubCommand
}
```

@emmatebibyte  let me know what you think, but otherwise see how it looks
